### PR TITLE
Error parsing EmailNotification fixed

### DIFF
--- a/src/main/java/com/brightcove/zencoder/client/model/EmailNotification.java
+++ b/src/main/java/com/brightcove/zencoder/client/model/EmailNotification.java
@@ -13,6 +13,8 @@
  */
 package com.brightcove.zencoder.client.model;
 
+import org.codehaus.jackson.annotate.JsonValue;
+
 public class EmailNotification extends Notification {
 
     private String address;
@@ -27,6 +29,7 @@ public class EmailNotification extends Notification {
         this.address = address;
     }
 
+    @JsonValue
     @Override
     public String toString() {
         return this.address;


### PR DESCRIPTION
I've tried to use email notifications and got an error from Jackson because it can't parse that object to JSON. 

I've fixed only with @JsonValue annotation