### PR TITLE
Make `cancelJob` use the correct API endpoint

### DIFF
--- a/src/main/java/com/brightcove/zencoder/client/ZencoderClient.java
+++ b/src/main/java/com/brightcove/zencoder/client/ZencoderClient.java
@@ -519,7 +519,7 @@ public class ZencoderClient {
      * @throws ZencoderClientException
      */
     public void cancelJob(String id) throws ZencoderClientException {
-        String url = api_url + "/jobs/" + id + "/resubmit.json";
+        String url = api_url + "/jobs/" + id + "/cancel.json";
 
         HttpHeaders headers = getHeaders();
         @SuppressWarnings("rawtypes")


### PR DESCRIPTION
`cancelJob` was using /resubmit.json instead of /cancel.json