### PR TITLE
Add support for parsing encoding finish response to ZencoderClient.

### DIFF
--- a/src/main/java/com/brightcove/zencoder/client/ZencoderClient.java
+++ b/src/main/java/com/brightcove/zencoder/client/ZencoderClient.java
@@ -442,6 +442,30 @@ public class ZencoderClient {
     }
 
     /**
+     * Parses payload from Zencoder notification.
+     *
+     * @param HttpEntity
+     * @return ZencoderNotificationResponse
+     * @throws ZencoderClientException
+     */
+    public ZencoderNotificationResponse parseNotificationResponse(HttpEntity<String> entity) throws ZencoderClientException {
+
+        ZencoderNotificationResponse response = null;
+        try {
+            response = mapper.readValue(
+                    entity.getBody(),
+                    ZencoderNotificationResponse.class);
+
+        } catch (Exception e) {
+            throw new ZencoderClientException(
+                    "Unable to deserialize ZencoderNotificationResponse as JSON",
+                    e);
+        }
+
+        return response;
+    }
+
+    /**
      * Gets the details of a given output.
      *
      * @see https://app.zencoder.com/docs/api/outputs/show

--- a/src/main/java/com/brightcove/zencoder/client/ZencoderClient.java
+++ b/src/main/java/com/brightcove/zencoder/client/ZencoderClient.java
@@ -42,6 +42,7 @@ import com.brightcove.zencoder.client.response.ZencoderCreateJobResponse;
 import com.brightcove.zencoder.client.response.ZencoderInputOutputProgress;
 import com.brightcove.zencoder.client.response.ZencoderJobDetail;
 import com.brightcove.zencoder.client.response.ZencoderJobDetailResponse;
+import com.brightcove.zencoder.client.response.ZencoderJobFinishedNotificationResponse;
 import com.brightcove.zencoder.client.response.ZencoderJobProgress;
 import com.brightcove.zencoder.client.response.ZencoderMediaFile;
 
@@ -445,16 +446,16 @@ public class ZencoderClient {
      * Parses payload from Zencoder notification.
      *
      * @param HttpEntity
-     * @return ZencoderNotificationResponse
+     * @return ZencoderJobFinishedNotificationResponse
      * @throws ZencoderClientException
      */
-    public ZencoderNotificationResponse parseNotificationResponse(HttpEntity<String> entity) throws ZencoderClientException {
+    public ZencoderJobFinishedNotificationResponse parseJobFinishedNotificationResponse(HttpEntity<String> entity) throws ZencoderClientException {
 
-        ZencoderNotificationResponse response = null;
+        ZencoderJobFinishedNotificationResponse response = null;
         try {
             response = mapper.readValue(
                     entity.getBody(),
-                    ZencoderNotificationResponse.class);
+                    ZencoderJobFinishedNotificationResponse.class);
 
         } catch (Exception e) {
             throw new ZencoderClientException(

--- a/src/main/java/com/brightcove/zencoder/client/response/ZencoderJobFinishedNotificationResponse.java
+++ b/src/main/java/com/brightcove/zencoder/client/response/ZencoderJobFinishedNotificationResponse.java
@@ -19,18 +19,18 @@ import com.brightcove.zencoder.client.request.ZencoderOutput;
 import com.brightcove.zencoder.client.response.ZencoderJobDetail;
 import com.brightcove.zencoder.client.response.ZencoderMediaFile;
 
-public class ZencoderNotificationResponse {
+public class ZencoderJobFinishedNotificationResponse {
 
-	private ZencoderJobDetail job;
-	private Collection<ZencoderOutput> outputs;
-	private ZencoderMediaFile input;
+    private ZencoderJobDetail job;
+    private Collection<ZencoderOutput> outputs;
+    private ZencoderMediaFile input;
 
-    public void setJobDetail(ZencoderJobDetail jobDetail) {
-        return jobDetail;
+    public void setJob(ZencoderJobDetail jobDetail) {
+        this.job = jobDetail;
     }
 
-    public ZencoderJobDetail getJobDetail() {
-        return jobDetail;
+    public ZencoderJobDetail getJob() {
+        return job;
     }
 
     public void setOutputs(Collection<ZencoderOutput> outputs) {
@@ -42,11 +42,10 @@ public class ZencoderNotificationResponse {
     }
 
     public void setInput(ZencoderMediaFile mediaFile) {
-        this.mediaFile = mediaFile;
+        this.input = mediaFile;
     }
 
-    public String getInput() {
-        return mediaFile;
+    public ZencoderMediaFile getInput() {
+        return input;
     }
 }
-

--- a/src/main/java/com/brightcove/zencoder/client/response/ZencoderNotificationResponse.java
+++ b/src/main/java/com/brightcove/zencoder/client/response/ZencoderNotificationResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2013 Brightcove Inc. All Rights Reserved. No use, copying or distribution of this
+ * work may be made except in accordance with a valid license agreement from Brightcove Inc. This
+ * notice must be included on all copies, modifications and derivatives of this work.
+ * 
+ * Brightcove Inc MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF THE SOFTWARE,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT. BRIGHTCOVE SHALL NOT BE
+ * LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THIS
+ * SOFTWARE OR ITS DERIVATIVES.
+ * 
+ * "Brightcove" is a registered trademark of Brightcove Inc.
+ */
+package com.brightcove.zencoder.client.response;
+
+import java.util.Collection;
+
+import com.brightcove.zencoder.client.request.ZencoderOutput;
+import com.brightcove.zencoder.client.response.ZencoderJobDetail;
+import com.brightcove.zencoder.client.response.ZencoderMediaFile;
+
+public class ZencoderNotificationResponse {
+
+	private ZencoderJobDetail job;
+	private Collection<ZencoderOutput> outputs;
+	private ZencoderMediaFile input;
+
+    public void setJobDetail(ZencoderJobDetail jobDetail) {
+        return jobDetail;
+    }
+
+    public ZencoderJobDetail getJobDetail() {
+        return jobDetail;
+    }
+
+    public void setOutputs(Collection<ZencoderOutput> outputs) {
+        this.outputs = outputs;
+    }
+
+    public Collection<ZencoderOutput> getOutputs() {
+        return outputs;
+    }
+
+    public void setInput(ZencoderMediaFile mediaFile) {
+        this.mediaFile = mediaFile;
+    }
+
+    public String getInput() {
+        return mediaFile;
+    }
+}
+


### PR DESCRIPTION
This PR essentially takes care of deserialising POST-payload received from Zencoder into a response object once encoding job is finished. For more information take a look at the JSON body from the following API documentation page: https://app.zencoder.com/docs/guides/advanced-integration/getting-zencoder-notifications-while-developing-locally